### PR TITLE
Add binder

### DIFF
--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,0 +1,1 @@
+pip install -e .

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,1 +1,2 @@
+pip install pandas vega uproot
 pip install -e .

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,0 +1,1 @@
+../requirements.txt

--- a/examples/example.ipynb
+++ b/examples/example.ipynb
@@ -1,0 +1,107 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from histbook import *\n",
+    "import numpy\n",
+    "from vega import VegaLite as canvas"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div class=\"vega-embed\" id=\"4dfeca9b-27fa-42a4-a2d2-dfc586731cfb\"></div>\n",
+       "\n",
+       "<style>\n",
+       ".vega-embed .error p {\n",
+       "    color: firebrick;\n",
+       "    font-size: 14px;\n",
+       "}\n",
+       "</style>\n"
+      ]
+     },
+     "metadata": {
+      "jupyter-vega": "#4dfeca9b-27fa-42a4-a2d2-dfc586731cfb"
+     },
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/javascript": [
+       "var spec = {\"$schema\": \"https://vega.github.io/schema/vega-lite/v2.json\", \"width\": null, \"height\": null, \"title\": null, \"config\": null, \"data\": {\"values\": [{\"a0\": -5.0, \"a1\": 0.0}, {\"a0\": -4.999999999, \"a1\": 2.0}, {\"a0\": -4.6, \"a1\": 12.0}, {\"a0\": -4.2, \"a1\": 59.0}, {\"a0\": -3.8, \"a1\": 268.0}, {\"a0\": -3.4, \"a1\": 1028.0}, {\"a0\": -3.0, \"a1\": 3268.0}, {\"a0\": -2.6, \"a1\": 9217.0}, {\"a0\": -2.1999999999999997, \"a1\": 21815.0}, {\"a0\": -1.7999999999999998, \"a1\": 44491.0}, {\"a0\": -1.4000000000000004, \"a1\": 77817.0}, {\"a0\": -1.0, \"a1\": 116210.0}, {\"a0\": -0.5999999999999996, \"a1\": 147243.0}, {\"a0\": -0.20000000000000018, \"a1\": 158265.0}, {\"a0\": 0.20000000000000018, \"a1\": 146224.0}, {\"a0\": 0.6000000000000005, \"a1\": 115149.0}, {\"a0\": 1.0, \"a1\": 77814.0}, {\"a0\": 1.4000000000000004, \"a1\": 44967.0}, {\"a0\": 1.8000000000000007, \"a1\": 22108.0}, {\"a0\": 2.1999999999999993, \"a1\": 9361.0}, {\"a0\": 2.5999999999999996, \"a1\": 3367.0}, {\"a0\": 3.0, \"a1\": 963.0}, {\"a0\": 3.4000000000000004, \"a1\": 277.0}, {\"a0\": 3.8000000000000007, \"a1\": 65.0}, {\"a0\": 4.200000000000001, \"a1\": 9.0}, {\"a0\": 4.6, \"a1\": 1.0}, {\"a0\": 5.0, \"a1\": 0.0}]}, \"mark\": {\"type\": \"line\", \"interpolate\": \"step-before\"}, \"encoding\": {\"x\": {\"field\": \"a0\", \"type\": \"quantitative\", \"scale\": {\"zero\": false}, \"axis\": {\"title\": \"data\"}}, \"y\": {\"field\": \"a1\", \"type\": \"quantitative\", \"axis\": {\"title\": \"entries per bin\"}}}, \"transform\": []};\n",
+       "var opt = {};\n",
+       "var selector = \"#4dfeca9b-27fa-42a4-a2d2-dfc586731cfb\";\n",
+       "var type = \"vega-lite\";\n",
+       "\n",
+       "var output_area = this;\n",
+       "\n",
+       "require(['nbextensions/jupyter-vega/index'], function(vega) {\n",
+       "  vega.render(selector, spec, type, opt, output_area);\n",
+       "}, function (err) {\n",
+       "  if (err.requireType !== 'scripterror') {\n",
+       "    throw(err);\n",
+       "  }\n",
+       "});\n"
+      ]
+     },
+     "metadata": {
+      "jupyter-vega": "#4dfeca9b-27fa-42a4-a2d2-dfc586731cfb"
+     },
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAARIAAAD1CAYAAACcAXqtAAAgAElEQVR4Xu2dDbBkRXmGnw2ClAoRFKJES+GiAUQEkYQ/CzUJGtgyRLOGNSTBUkiUvwSNLJayUCRxFwMGFYHwGxPdxUiI4YqAhAUiREBioESRZEGUgIAKAgKiMKkXetjZ2Zk5ffr0mdsz9z1VFHtnuvt8/Xb3M1/36f7OAnxZAStgBRoqsKBhfme3AlbACmCQuBNYASvQWAGDpLGELsAKWAGDxH3ACliBxgoYJD0Snn/++bftuOOOWzZW1QVYgelUYNXMzMybBlXNIOlRZdmyZZ0lS5Zk02T16tWdmZmZbOXl7psl2bdwyYor+us386KN9lr9g4eu7P18dtniN+TWIbW8kvQbVIfc9o0qr9hOntq4TfIZJE3Ua5Z34ZKVnZgSZpftX0yfzT1QY+pfJ01u+wySSPUNkkihWki2BiSdN3aLP2zhtqs+Ofvt8PeCVfrcIIkX3yCJ1yprSoMkq5y1CuuCpBcUvQNh0Pe1btBC4twDNbeJue2zRxLZQgZJpFAtJDNI8otqkOTXNKpEgyRKplYSGST5ZTVI8msaVaJBEiVTK4kMkvyyTjNINgPu65FsY3hmm75W7R8M3ymdvrsD+MUAiTcCtgDuAh7q+X5QvmcBLwMeBu4Z1VwGSf7OHFuiQRKrVHy6aQTJc4DXAGcCOwBPABsCNwM3AILI7cCHgLcA5wCfA94K7Aw80COfNozdBpwAfDCUexOwz4B8jwOXAjcC2n9wPLByWFMYJPGdNHdKgyS3ojCNIDkSOAq4FtgPeBJ4SQDHIQEkUrILl92Ae4HDgfWBE3tkXgGcBmij0k7AucCuwDeB/nx3A9sAxwDPDQB6RY/ns1brGST5O3NsiQZJrFLx6aYRJKr9y4EvhsEvkGhA39ojy8LgOVzS47XsAewNLA3pBJWrgX3DFGkTQDsi5blcNCDfBsCFwDVhCnUZcAAgwKxzGSTxnTR3SoMkt6LT6ZFIJXkG5/WARJB4HXBq+O4rARAnhWmIYLMt8N7gmagMeRW3BGDcH/6+CjgQOGVAvq2A44DrA0g0rTk6eCYGSUFb+A0SgyRWAXkgX+gBibwFrWHo0rbny4FDwzrH7mGRdXFYVO1ObZROMDoieBVbA+cDgpLy9+fT4q3WXuSJaNqktRJNg+5fvnz50k6nc2y/8YsWLYqtj9NlVOCIM8R6OPmgXQaWWvV9RlNc1AgFhp0dG+e5hX6P5CPAY8DHwnqJFl23D1OVd4f1lJMBeRyatghEAsHpYUokuGi9RYusWktR/v58WsQVdLTNWt7JxeEej3pqk9/1bTIC7ZE0UW9w3mldI5H3cHbP9EOLrVow1QDX9TbgAuC1AQr67CzgYGBGxyyA7YBNA2z0bz296T7VGZRPINE9NfXRpSdHesIz8PIaSf7O3C0x5VCet8g3a49pBckwVbRgKg9B3kn30uPi54UnN/pMayN6dKyFUj06Xi8AReskvftM+vN1y9sceCTsJRnaOgZJs447KncukEBnrbAC/fccZ5iB3AM1t/q57ZuGszbPD2C5M7fYveUZJO2pm3LobpBHUmXhOE8H5x6oVXWr+31u+6YBJHU1TEpvkCTJFpWpOUhWVAQ0Gn+YgdwDNUrIGoly22eQRIpvkEQKlZCsKUiqbplSflWZVd/nHqhV96v7fW77DJLIFjBIIoVKSJYy0OsMhJTyE6qxVpY69jW9V0r+3PYZJJGtYJBECpWQLGWg1xkIKeUnVMMgGRKDeJz7SJq2W+v5DZL2JE4Z6AZJs/aoo1/MneyRxKgEGCSRQiUkM0gSRGuYxSBpKGBqdoMkVbnqfAZJtUa5UxgkuRWNLM8giRQqIZlBkiBawywGSUMBU7MbJKnKVeczSKo1yp3CIMmtaGR5BkmkUAnJDJIE0RpmMUgaCpia3SBJVa46n0FSrVHuFAZJbkUjyzNIIoVKSGaQJIjWMItB0lDA1OwGSapy1fkMkmqNcqcwSHIrGlmeQRIpVEIygyRBtIZZDJKGAqZmN0hSlavOZ5BUa5Q7hUGSW9HI8gySSKESkhkkCaI1zGKQNBQwNbtBkqpcdT6DpFqj3CkMktyKRpZnkEQKlZDMIEkQrWEWg6ShgKnZDZJU5arzGSTVGuVOYZDkVjSyPIMkUqiEZAZJgmgNsxgkDQVMzW6QpCpXnc8gqdYodwqDJLeikeUZJJFCJSQzSBJEa5jFIGkoYGp2gyRVuep8Bkm1RrlTGCS5FY0szyCJFCohmUGSIFrDLAZJQwFTsxskqcpV5zNIqjXKncIgya1oZHkGSaRQCckMkgTRGmYxSBoKmJrdIElVrjqfQVKtUe4UBkluRSPLM0gihUpIZpAkiNYwi0HSUMDU7AZJqnLV+QySao1ypzBIcisaWZ5BEilUQjKDJEG0hlkMkoYCpmY3SFKVq85nkFRrlDuFQZJb0cjyDJJIoRKSGSQJojXMYpA0FDA1u0GSqlx1PoOkWqPcKQyS3IpGlmeQRAqVkMwgSRCtYRaDpKGAqdkNklTlqvMZJNUa5U5hkORWNLI8gyRSqAHJFi5Z8YbRuRes0vezy/ZfEHuXOgMhBVSxdgxLV8e+pvdKyZ/bvlHlRTdqSkUmLY9Bkt5i3YFcVYJBUqVQvu8Nknxa1irJIKkl11qJ14Ckc+WoUmaXLa7wXNbkrjMQ2gBZlRp17Ksqq43vc9tnjySylQySSKEGTm1WdupOXaruVmcgGCTrqllHv6q20PcGSYxKgEESKVSBIKmyvI01lNwDtaoOdb/PbZ9BEtkCBkmkUAbJUwrkHqjp6g/Omds+gySyhQySSKEMEoOkrw/4qU2PIAaJQVJHgdy/+HXuHZM2t332SGJU9xpJpEqDk5W+BlG6fY3EH5K5dJCsD/xSn+0/a0OIcZdpjyRd8dIHaun2pSs/PGfJINkPuKDP9HuBbYD72xBjnGUaJOlqlz5QS7cvXfnJA8mGwLXAlsA5wJOhCs8BPgA81IYY4yzTIElXu/SBWrp96cpPHkieC1wHLAEubKPic12mQZLeAqUP1NLtS1d+8kAii08HNgGWAo8DeuqjHY13AL9oQ4xxlmmQpKtd+kAt3b505ScTJOcB7xhg+guAH7chxjjLNEjS1S59oJZuX7rykwmSPYNH8tS5inA9C/gyMPFPbgyS9O5c+kAt3b505ScLJFpQ1VRGj331Xz9IftqGEOMu0yBJV7z0gVq6fenKTw5ItMh6E3AC8ErgyD7T/fh3SFvmfo6fu7PltK/0gVq6fbnbVuXlbN+q8mK2yD9bmz7D9OXFwGuAx3oqrsfCxwAPR4ixGXBf37ToZSHvPT2fK93GIxZxNwK2AO7qe+w8KJ+mXoPusY659kgiWnBIktIHaun2pSs/OR5Jv6U7AK8PH8pT+WrfVGdQzTQ1EoDOBJT/CUCfXQrcCCjYzfHASmCfsE/lc8BbgZ2BB3oK1T6W24KH9MFQruwYlE/TsUH3GKi+QZLenUsfqKXbl678ZILkvcCn+0z/PPDOAIdhtdJ06KiwoU27Y7WZTXm0I1bejKZPgsP2wNeA3QBNmQ4HtCX/xJ6CVwCnAYrEtRNwLrAr8M0B+e4ecI9XAA8OMtQgSe/OpQ/U0u1LV37yQKIpzA3A93t2sv4BsBz4NeDWCjFeDnwxDH6B5KNhY9s1YT/KZcBfAv/Y47XsAewd9q2oeEHlamDfMEXSnpYrgudy0YB8Gwy4xwGAAOOpzerVnZmZmZjpbWU/L32glm5fpcAJCUpbI+lWQU9r5C38A3BK+HAG+F9gK+D2irrK+9A+FHkRAskscBxwfQCJpjWa+nwkTHWUZltAXpA8E13yXG4JwNDZHv19FXBgsElTpN58sqv/HkfL+1m+fPnSTqdzbL/NixYtSmgyZzniDDUjnHzQLkWKUbp9RYo2wKhhPzwxv0ZK88awDqJ1DE0NDgF+BLwLeDMgb+PRCjGU7ws9IDkowEeeiLwdrZW8KRwK3D3slF0cFlW7UxvZIhgdEbyKrYHzAXkulwP9+TSFEeB676Fp0MADhp7apHfn0n/xS7cvXfnJmdroV3/UExkd1hNIqna29nskbw9AEKTkOVwcFlY1dXl3WE85OXgcmrYIRIKNtulrGiW4aL1Fi6zyWDTt6s+n/S6CTu89tA4zEHoGSXp3Ln2glm5fuvKTAxJZqoGu9YZhl6Y3VWdt5D2c3TNtkXehvzUt0aWnOnr68toABX12FnAwoCmUpkLbAZuGdRH9Wwu03ac6g/IJJIPuMbAeBkl6dy59oJZuX7rykwWSNurZLXNz4JE+r0ePhp8Xntx010a0fqKFUj06Xi8ARVOUXoD15xt1j3XqZJCkN3PpA7V0+9KVN0jqaPf8AJY762Sqm9YgqavYmvSlD9TS7UtX3iBpQ7tGZRok6fKVPlBLty9d+ckDiRZdtedDi5yfaaPic12mQZLeAqUP1NLtS1d+8kCixdFPAW8Bfh34SU8VqhZa29Ape5kGSbqkpQ/U0u1LV37yQCKL9ehVT1F6L5/+HdKWuXcW5u5sOe0rfaCWbl/utlV5Odu3qryYDWm9dXxfeEyrpyzdy8GfDRJKH6il2zffQKL6amPYb4Q9HNqo9p1piI6minlqk96dSx+opduXrvxkTm10EEWnfXVpiqMt6YrX+nsVp3/b0Cl7mQZJuqSlD9TS7UtXfvJA0j39q63sOsOioEKKHn8J8CrgW22IMc4yDZJ0tUsfqKXbl6785IGkG3Jxf+CFwEsBBR/SWZsdwzmYNvQYW5kGSbrUpQ/U0u1LV37yQKIwAv8ezrbcHACi+CA68zI0WFAbArVVpkGSrmzpA7V0+9KVnzyQyOKXAF8K8UC6NVAYAYUznPjLIElvwtIHaun2pSs/mSCR1Qq8/LoQrUxBhr7XhghzUaZBkq566QO1dPvSlZ9MkPz2AO9DQY7647i2oUvrZRok6RKXPlBLty9d+ckDiV7roPioWg9RIOcfAu8PayZ6aqNYrhN9GSTpzVf6QC3dvnTlJw8kempzXQgU1A19qPfFfNePfwc3Zu4tyrk7W077Sh+opduXu21VXs72rSqv7hb5TwCKdHZoeNeMYrbq3TKKmapt8wq32PvyrDb0aa1MeyTp0pY+UEu3L135yfNIZLECL79jRKUFFIUamMjLIElvttIHaun2pSs/mSDRO2YUM3XQpTUURXLXjteJvAyS9GYrfaCWbl+68pMJkjbqW0yZBkl6U5Q+UEu3L115g6QN7RqVaZCky1f6QC3dvnTlDZI2tGtUpkEyXL6FS1boLYYjrgWr9OXssv3rLuAPLTPnU4cuSKCjdxwNvWaXLdYWh6grp31RN6yZKLd9o8pLaXQd1lM0d73wSu+70eLqwDfX1az3nCc3SEaBZKXeEVR5lQ+S0VWoY3/ugVopbs0Eue3LCRLtYj0G0MvDn/oFCm+908utJvaxb7d9DJIYkHSurPhFr/Bc4kdDzoGwcMmKCk9jwV51Paqc9sWrEp8yt325QNKNR/LZ8FKqD4cXfJ8E7At8Pb6KZaY0SKpBUucXu2kr5x4Io+xJWUMZp30pWua2LxdIuvFIfh94T4hHon9/I7x28+nX0U/wZZAYJHVAmXug5h46ue3LBZJuPJKu63o8oDfgHRbWSm7PLcS4yzNIDBKDZHgfyAUS3eHVwKnh3bt/BHwR0Dt5Pz7uQd/G/QwSg8QgGQ9IdJfeKPJ6MdaNjiI/WPzcrmVueNaxL2UNoam9dexreq+U+o3TvpT65bYvp0fiKPI1WjR3Q9a4dVTSOvalDLQoI0YkqmNf03ul1G+c9qXUL7d9uUDiKPI1WzN3Q9a8fWXyOvalDLRKAyoS1LGv6b1S6jdO+1Lql9u+XCBxFPmarZm7IWvevjJ5HftSBlqlAQZJU4lG5q/TvjGG5AKJo8jHqN2TJndD1rx9ZfI69hkk68pZR7/KxmghQW77coFEVXUU+RoNnrsha9w6Kmkd+wwSgyQHSPSi8McBeSX6Ty/I0jttfhRe1fnTqJ5beCI//h3eQAaJQdIUJN21kROAVwJH9kl6bzjAN/EH9wwSg8T7SIb3gaYgeTawDPgy8GKg/4CenuboIN/DhTscleYZJAaJQdIeSLolK5SiXoz1gxA5vnJgTloCg8QgMUjaB0l3H4le2anI8VN3GSQGiUHSPkh0h78GPhTWSe4It5SnMhteRzHRcDFIDBKDpH2QKJrayiGvo3hBeKeNQdKjQJ3Hq3MhXB37/NTGT22aLrb2Kqjwij8PgY26nwsi/w08OReDIec97ZHYI7FH0q5HshGgx8ArgFOAq8I+EsUj+U9Ar+7049++Nqjzi58TiLFl1bHPHok9khweyYHAOUM6qPeRDBGmzkCNHfw509WxzyAxSHKARFOaHYGPAP8SwituEKQVSBQIOirKeM6BkLssT208tfHUpt2pTbf0bYF7gP4t8T/LPajnojyDxCAxSMYDkv2AC/pu5amNpzatcL/O1KupASlTt3Hal1K/3PblmNqoHtqQdi2wZVgv6T6l0YG+DwAPpVS2pDz2SOyR2CNp3yPRU5vrgCXAhSUBIJctBolBYpC0DxLd4XRgE2BpCCugTWpaZNUuVwWCnujLIDFIDJLxgOQ872yNZ2XuOWr8neNS1rEvZQ0hzoq0jtu07P78KfWro19ue2PKy21frjUS2b5n8Eh6H/XqrI1CDEz8kxt7JPZI7JGkgV1Tk7pX73ttFIPkO9MAEYlgkBgkBsl4QJL7vTYbA12Yyct5MFRjM0DfDVt70Zb9LYC7+p4WDconj0lb+AU97YEZehkkBolB0j5Icr/XRuXdDNwQFmz17mCFKHhLeLz8OeCtwM7AAz3V0+Pn2wCFflRcFEVsuwnYZ0A+xZm9NLwNUO8s1vuKdYJ54GWQGCQGSfsgyf1eG0WkFzgO6dle34XLboA2uh0eDgee2FM9HRw8DbgS2Ak4F9gV+CbQn+/uEE9WoSBlvwCkqVnX81lLNYPEIDFI2gdJ7vfaaEDf2mP2wuA5XALsEKLT7wHsHR43K6ki118N7AvcFxZ+rwiey0UD8uk8kPa8XBOmUJcBBwACzDqXQWKQGCTtg0R3yPleG0FCMWBPDV7DVwIgTgI0DdHOWZ3teW/wTHR/eRW3BGAobIH+VkgDnU5WeIP+fFsBxwHXB5BoWnN08EwMktWrOzMzM1EL7imPR0etR8V8l/vx5ah7ptRvnPbF6NWfJrd9OR//dm3dvOe9No+lVBKQt6A1DF3qzJcDh4Z1jt3DBrfFYVG1O7VROu1lOSJ4FVsD5wOCkvL359MURmsv8kQ0bboxTIPuX758+dJOp3Nsv+2LFmk92Ve/AkecIRbDyQftMpXiTHv9cjXasB+eqF+jXEb0laOQBILQx4Kno0XX7QFNVd4dzvWcHDwOTVs0FRIItLtWUyLBRYcItciqtRTl78+nJ0GCzhsBeScXh3s86qkN1PnFSvnFbtpv6tjX9F4p9RunfSn1y21fGx5JSr3682iapAVTDXBdbwsni18boKDPzgIOBmZCgOntgE0DbPRvLZ52n+oMyieQnB2mPiqv+4RnoP1eIxnerCkDrWknyT0QRtmTUr9x2peiZW77SgVJVxud3ZGH0DtF0oni54UnN0qntZAzw0LpE8B6AShaJ+k949Ofr3sPTcUeqXqJl0FikHixdXgfKB0kMbBVbFiB5c6YxKlpDBKDBDqaBg+9Zpct1tT7qSv3L35qvx2WL7d90wCS3Bp7atM3EBYuWbHOwvPaIi3QiW/q/GI3bbTcAyFmalNlc2/9x2lflV2Dvs9tn0ES2Qrz2SPprhFUSTW9IFnxjKcxWIMFe/WDNPdArdK+7ve57TNIIlvAIJFQHe27GeXaV3gukWJHJMs9ECJuOTTJoMXYkuyzR9KkdTPnNUjGO3Wpar6SBqpBMnpNaC73kVT1o7F/b5AYJMM6nUFikEQDySAxSAyS4cPFaySRKDFIDBKDxCCJxMXwZAaJQWKQGCQGSU0Fel3VlC3iNW9XO7kXW2tLtlaG3Pp5ahPZHvZI7JHYI7FHEokLT226Ctgjie8yfmrjpzbRvcUeiT0SeyT2SKKBMSyhQWKQGCQGiUFSUwFPbeIF89TGU5vo3mKPxB6JPRJ7JNHA8NTmaQXskcR3GXsk9kiie4s9Ensk9kjskUQDwx6JPZK6ncUeiT2S6D5jj8QeiT0SeyTRwLBHYo+kbmexR2KPJLrP2COxR2KPxB5JNDDskdgjqdtZ7JHYI4nuM/ZI7JHYI7FHEg0MeyT2SOp2Fnsk9kii+4w9Ensk9kjskUQDwx6JPZK6ncUeiT2S6D5jj8QeiT0SeyTRwLBHYo+kbmexR2KPJLrPTLNHsnDJijf0C3HYwm1XfXL22+Gl2QtW6ftxvpKzqmFyxxytut+o79e80rRzZTfdzIs22mv1Dx565u+n9Vu8js5N7tskb279HLM1sjWmGyQrOzEyGCSDVSrx3chV7WmQVCnU0vfzAyTz9xe1SbexR+epTXT/mQ8g6fU4cv9iRQsdmXCS7JsPr/Pw1Cay4xokkUKNKZlB0kzo3PoZJJHtYZBECjWmZLkHQm6z51uEOYMksgcZJJFCjSmZQdJM6Nz6GSSR7WGQRAo1pmS5B0Jus+2RrFF0QW5xJ7k8g6Ss1jNImrVHbv3skUS2h0ESKdSYkuUeCLnNtkdij2RgnzJIcg+1ZuUZJGXpZ48ksj0MkkihxpTMIGkmdG79DJLI9jBIIoUaU7LcAyG32Z7aeGrjqU3fm/ZyD7Ic5RkkzVTMrZ89ksj2sEcSKdSYkuUeCLnNtkdij8QeiT2SxlwxSAySqQPJwiUrjh09MhYs1fc+tNeYH88UMAgksOZ09aA7jTNeSW6PzlObyL4zyVOblHgZuTtapMzRySbJvhT9o4VITJhbP4MksiGmAySd40ZVd3bZ4mc8l9wdLVLm6GSTZN+geCVrV3T8Eehy62eQRHbdaQBJnQhnuTtapMzRyabJvrmIV5JbP4MksusaJJFCjSlZ7oGQ2+w69hkkudUvuDyDpKzGqTNQ58LyOvYZJHPRQnN0T4NkjoQfcts6A3UuLK9jn0EyFy00R/c0SOZI+HkEEuiE138MrvTsssVX5GqFOqCLuafXSGJUAkoGSRuPF3N3tEiZo5NNk31ttF+VkLn1m+8geRbwMuBh4J5R4hskVV1zvN/nHgi5ra9j38IlKyo8jQV7yb46T92q6lPHvqqy9P18BslzgEuBGwG9Ae14YOUw0eYSJHOxDyF3R4vpjHXSzCf7et7kl23qk1u/+QySdwLbAMcAzwVuA14BPDioQ7cJklhQVA20kn+xqmyv+33ugVD3/lXpc9oXO/Wps8aS07757pF8FLgQuAZQfNrLgAOAu/s7iRpyz+d/l68+8PKq/tPy9+M7q5G7o+UWZj7ZFzv1ya1x3fKG/ZBNe/DnWUBbxq8PING05mh5JsuXL1/a6XTWOuj2WGd9Nlzw87raOr0VmBcKbLPNNg/st99+mwyq7LSD5CDg9uCJbBjWSnYF7h9Hy+eeKuW22fY1U9T6rdFv2kHyduAIQAtYWwEXA9sDjzbrQnG53dHidBrX4ncza9bN7fadPyARKM8GDgxVfg1wU+4O5YHQjqIeqM10Had+0+6RdFtic+CRsJekWevUyD3Ohqxh1jNJbV+KamvyWL/545E06ykNc2tB96ijjhoZH6ThLRplt32N5MP6GSTNepBzWwErsJYC82Vq42a3AlagRQUMkhbF7Sla531+Bfi/8dyu1l1eDPxysO2hWjnbTbwRsAVwF1CSXd1ay75fDVsJRp7halemytJfCtwJdCpTNkhgkDQQr0ZWbYLTjtodgCdq5Gs76TuAT4YnW0uA1wE3tH3TiPK3DMcZTgA+CIz1aVuEfa8OT/+WAdLwb4CzIvKNO4kOAmpntw6ttrp3yiBpv2nVmDr5qQbdD3iy/VtG3UFnj3Qi+gXAj4HfCoPi4Kjc7SZaAZwGXAnsBJwb/l+KdtqPpOMXsm8z4Gvj3J8UKf2LwgZMJdd5M4MkUrgSk2naIIgsAj4VNsaV5JHosfi94fjAycAdwIlzLOT6wNXAvsB9gLZkS8OdgV/MsW3d2wseDwA6T6EfBz2ZE/BKAd0vAVcBfwqcA7zZICmk50SaIe/jD4H/Af4OWAX8SRgA/1ZAZ+u1T8BQx9c04l+B7wfbfxJZ17aSyVO6JUwD9SuqvzUodLShpINQWiORhr8L7BnavC1N6parqbSOhvwz8C1gl2En3usWPCy9pza5lHy6HM2dXxWmDKtDI2onrdZGdH0eWDyHv1y99n0pxGi5HFgI6O8SLvXJ88LRBp3S3ho4vwAI92rzkgDe9wdP8/EShAs2dMNlyNvsXlpsVR9sbXpjkLTXAzYIbrl+RQWXM4HdwnpEe3eNL1mHGG8GFLNFC6wKAqUB8Vh8Ea2lPB24Nfzia+qwD1DC2k23wrJPmun4xbPD1FDrTaVcgoimgfKavgrsDXy7TeMMkjbVXVO2flXPAH5zDr2R/prq0eV/Ab2/XIcCp4xHkpF30RqE1kW2C09vtD6iNYkSLj3Kl2179BjzHwWuf8k8/VhcC7zeU5sSuo5tmAsF1gM2De54KYusc6HDRNzTHslENJONtAJlK2CQlN0+ts4KTIQCBslENJONtAJlK2CQlN0+ts4KTIQCBslENJONtAJlK2CQlN0+ts4KTIQCBslENJONtAJlK2CQlN0+88E6vflQu1i16Uwb5AZd2gSm08nfC8cO5oMuE1VHg2SimmsqjdWrDXXATAfLvj6khjoRrIN8Hw9nW6ZSiEmulEEyya03ubbryL0CKskb+SzwFwEkOr/yHuDvQ1S0vw3p9O7mPw+f6dCjtqR/CDgqBBgSYD5T0PGDyW2ZRMsNkkThnC1ZgReGw4IqQIBQBDS9vEweic7/KKTBIYDCGfwTcDjwwxCW4RvABwC9QfFd4cChDkIKKqM8mmRjneSbb7IAAAFsSURBVDFOAYMkTienyqdAN2KcAKDIYruHQEYCgUIv6LSvpjIKr/g+QAcJ5aFo2iMvRqeoFUNFcUB0kE/p9W+DJF8b1S7JIKktmTM0VOB3gIuAHUMoQJ2MViAogUDrJQrGsxy4LsQhEUgUD1XTHk1hBJJPAIcFz0VBjT9tkDRslYbZDZKGAjp7bQUUflKR4QWMk8L0RnARSP44vF5V0dDkdcyGaYxiuAosCr6kPJeEI/LyZv4M+KseMNU2yBmaK2CQNNfQJdRXQDFsFS2u91IEewUJUrxWXYrcphe+K92RwAUhjuuHgR8Bp4Z0ApLK0yLsyvqmOEcOBQySHCq6jBQFFL1LQYr7Y8QqUpvWSAbFjhVoFJtEAbQ3Dv//acrNnSevAgZJXj1dmhWYlwoYJPOy2V1pK5BXAYMkr54uzQrMSwUMknnZ7K60FcirgEGSV0+XZgXmpQIGybxsdlfaCuRVwCDJq6dLswLzUoH/B0bTnMee0mExAAAAAElFTkSuQmCC"
+     },
+     "metadata": {
+      "jupyter-vega": "#4dfeca9b-27fa-42a4-a2d2-dfc586731cfb"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "array = numpy.random.normal(0, 1, 1000000)\n",
+    "histogram = Hist(bin(\"data\", 25, -5, 5))\n",
+    "histogram.fill(data=array)\n",
+    "histogram.step(\"data\").to(canvas)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This PR adds Binder integration and an example notebook

two directories are added to the repo root

* binder

this includes a soft link to the `requirements.txt` as well as a `postBuild` file that installs the optional dependencies as well as histbook in `editable` (`-e`) mode

* examples

this includes an example notebook (the gaussian histogram from the README)

Try it out here:

[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/lukasheinrich/histbook/addBinder?filepath=examples%2Fexample.ipynb)
