### PR TITLE
Consider minimizing Hist pickle size

### DIFF
--- a/histbook/axis.py
+++ b/histbook/axis.py
@@ -194,11 +194,9 @@ class Axis(object):
     def __ne__(self, other):
         return not self.__eq__(other)
 
-    _packtype = []
-
     @staticmethod
     def _unpack(args):
-        return Axis._packtype[args[0]](*args[1:])
+        return args[0](*args[1:])
 
 class GroupAxis(Axis):
     """Abstract class for histogram axes that fill bin contents as a dict (dynamic memory allocation)."""
@@ -287,9 +285,7 @@ class groupby(GroupAxis):
         return [IntervalPair((n, content[n])) for n in sorted(content)]
 
     def _pack(self):
-        return (Axis._packtype.index(self.__class__), getattr(self, "_original", self._expr))
-
-Axis._packtype.append(groupby)
+        return (self.__class__, getattr(self, "_original", self._expr))
 
 class groupbin(GroupAxis, _RebinFactor):
     """
@@ -467,9 +463,7 @@ class groupbin(GroupAxis, _RebinFactor):
         return [IntervalPair((Interval(n, n + float(self._binwidth), closedlow=self._closedlow, closedhigh=(not self._closedlow)), content[n])) for n in sorted(content)]
 
     def _pack(self):
-        return (Axis._packtype.index(self.__class__), getattr(self, "_original", self._expr), self._binwidth, self._origin, self._nanflow, self._closedlow)
-
-Axis._packtype.append(groupbin)
+        return (self.__class__, getattr(self, "_original", self._expr), self._binwidth, self._origin, self._nanflow, self._closedlow)
 
 class bin(FixedAxis, _RebinFactor, _RebinSplit):
     """
@@ -685,9 +679,7 @@ class bin(FixedAxis, _RebinFactor, _RebinSplit):
                              ([IntervalNaN()] if self.nanflow else []))
             
     def _pack(self):
-        return (Axis._packtype.index(self.__class__), getattr(self, "_original", self._expr), self._numbins, self._low, self._high, self._underflow, self._overflow, self._nanflow, self._closedlow)
-
-Axis._packtype.append(bin)
+        return (self.__class__, getattr(self, "_original", self._expr), self._numbins, self._low, self._high, self._underflow, self._overflow, self._nanflow, self._closedlow)
 
 class intbin(FixedAxis, _RebinFactor, _RebinSplit):
     """
@@ -873,9 +865,7 @@ class intbin(FixedAxis, _RebinFactor, _RebinSplit):
                              ([Interval(int(self._max), float("inf"), closedlow=False, closedhigh=True)] if self.overflow else []))
 
     def _pack(self):
-        return (Axis._packtype.index(self.__class__), getattr(self, "_original", self._expr), self._min, self._max, self._underflow, self._overflow)
-
-Axis._packtype.append(intbin)
+        return (self.__class__, getattr(self, "_original", self._expr), self._min, self._max, self._underflow, self._overflow)
 
 class split(FixedAxis, _RebinFactor, _RebinSplit):
     """
@@ -1138,9 +1128,7 @@ class split(FixedAxis, _RebinFactor, _RebinSplit):
                              ([IntervalNaN()] if self.nanflow else []))
 
     def _pack(self):
-        return (Axis._packtype.index(self.__class__), getattr(self, "_original", self._expr), self._edges, self._underflow, self._overflow, self._nanflow, self._closedlow)
-
-Axis._packtype.append(split)
+        return (self.__class__, getattr(self, "_original", self._expr), self._edges, self._underflow, self._overflow, self._nanflow, self._closedlow)
 
 class cut(FixedAxis):
     """
@@ -1205,9 +1193,7 @@ class cut(FixedAxis):
         return [False, True]
 
     def _pack(self):
-        return (Axis._packtype.index(self.__class__), getattr(self, "_original", self._expr))
-
-Axis._packtype.append(cut)
+        return (self.__class__, getattr(self, "_original", self._expr))
 
 class _nullaxis(FixedAxis):
     def __repr__(self):
@@ -1281,6 +1267,4 @@ class profile(ProfileAxis):
         return hash((self.__class__, self._expr))
 
     def _pack(self):
-        return (Axis._packtype.index(self.__class__), getattr(self, "_original", self._expr))
-
-Axis._packtype.append(profile)
+        return (self.__class__, getattr(self, "_original", self._expr))

--- a/histbook/axis.py
+++ b/histbook/axis.py
@@ -231,6 +231,9 @@ class groupby(GroupAxis):
     def __init__(self, expr):
         self._expr = expr
 
+    def _pack(self):
+        return (self.__class__, getattr(self, "_original", self._expr))
+
     def __repr__(self):
         return "groupby({0})".format(repr(self._expr))
 
@@ -284,9 +287,6 @@ class groupby(GroupAxis):
             raise TypeError("groupby content must be a dict")
         return [IntervalPair((n, content[n])) for n in sorted(content)]
 
-    def _pack(self):
-        return (self.__class__, getattr(self, "_original", self._expr))
-
 class groupbin(GroupAxis, _RebinFactor):
     """
     Describes an axis of sparse, numeric values. 
@@ -319,6 +319,9 @@ class groupbin(GroupAxis, _RebinFactor):
         self._origin = self._real(origin, "origin")
         self._nanflow = self._bool(nanflow, "nanflow")
         self._closedlow = self._bool(closedlow, "closedlow")
+
+    def _pack(self):
+        return (self.__class__, getattr(self, "_original", self._expr), self._binwidth, self._origin, self._nanflow, self._closedlow)
 
     def __repr__(self):
         args = [repr(self._expr), repr(self._binwidth)]
@@ -462,9 +465,6 @@ class groupbin(GroupAxis, _RebinFactor):
             raise TypeError("groupbin content must be a dict")
         return [IntervalPair((Interval(n, n + float(self._binwidth), closedlow=self._closedlow, closedhigh=(not self._closedlow)), content[n])) for n in sorted(content)]
 
-    def _pack(self):
-        return (self.__class__, getattr(self, "_original", self._expr), self._binwidth, self._origin, self._nanflow, self._closedlow)
-
 class bin(FixedAxis, _RebinFactor, _RebinSplit):
     """
     Describes an axis of regularly spaced, dense, numeric values. 
@@ -509,6 +509,9 @@ class bin(FixedAxis, _RebinFactor, _RebinSplit):
         self._nanflow = self._bool(nanflow, "nanflow")
         self._closedlow = self._bool(closedlow, "closedlow")
         self._checktot()
+
+    def _pack(self):
+        return (self.__class__, getattr(self, "_original", self._expr), self._numbins, self._low, self._high, self._underflow, self._overflow, self._nanflow, self._closedlow)
 
     def _checktot(self):
         if self.totbins == 0:
@@ -678,8 +681,6 @@ class bin(FixedAxis, _RebinFactor, _RebinSplit):
                              ([Interval(float(self._high), float("inf"), closedlow=self._closedlow, closedhigh=True)] if self.overflow else []) +
                              ([IntervalNaN()] if self.nanflow else []))
             
-    def _pack(self):
-        return (self.__class__, getattr(self, "_original", self._expr), self._numbins, self._low, self._high, self._underflow, self._overflow, self._nanflow, self._closedlow)
 
 class intbin(FixedAxis, _RebinFactor, _RebinSplit):
     """
@@ -711,6 +712,9 @@ class intbin(FixedAxis, _RebinFactor, _RebinSplit):
         self._underflow = self._bool(underflow, "underflow")
         self._overflow = self._bool(overflow, "overflow")
         self._checktot()
+
+    def _pack(self):
+        return (self.__class__, getattr(self, "_original", self._expr), self._min, self._max, self._underflow, self._overflow)
 
     def _checktot(self):
         if self._min > self._max:
@@ -864,9 +868,6 @@ class intbin(FixedAxis, _RebinFactor, _RebinSplit):
                              [i for i in range(int(self._min), int(self._max) + 1)] +
                              ([Interval(int(self._max), float("inf"), closedlow=False, closedhigh=True)] if self.overflow else []))
 
-    def _pack(self):
-        return (self.__class__, getattr(self, "_original", self._expr), self._min, self._max, self._underflow, self._overflow)
-
 class split(FixedAxis, _RebinFactor, _RebinSplit):
     """
     Describes an axis of irregularly spaced, dense, numeric values. 
@@ -908,6 +909,9 @@ class split(FixedAxis, _RebinFactor, _RebinSplit):
         self._nanflow = self._bool(nanflow, "nanflow")
         self._closedlow = self._bool(closedlow, "closedlow")
         self._checktot()
+
+    def _pack(self):
+        return (self.__class__, getattr(self, "_original", self._expr), self._edges, self._underflow, self._overflow, self._nanflow, self._closedlow)
 
     def _checktot(self):
         if self.totbins == 0:
@@ -1127,9 +1131,6 @@ class split(FixedAxis, _RebinFactor, _RebinSplit):
                              ([Interval(float(self._edges[-1]), float("inf"), closedlow=self._closedlow, closedhigh=True)] if self.overflow else []) +
                              ([IntervalNaN()] if self.nanflow else []))
 
-    def _pack(self):
-        return (self.__class__, getattr(self, "_original", self._expr), self._edges, self._underflow, self._overflow, self._nanflow, self._closedlow)
-
 class cut(FixedAxis):
     """
     Describes an axis of two bins: those that fail and those that pass a boolean expression.
@@ -1144,6 +1145,9 @@ class cut(FixedAxis):
 
     def __init__(self, expr):
         self._expr = expr
+
+    def _pack(self):
+        return (self.__class__, getattr(self, "_original", self._expr))
 
     def __repr__(self):
         return "cut({0})".format(repr(self._expr))
@@ -1191,9 +1195,6 @@ class cut(FixedAxis):
     def keys(self, content=None):
         """Returns key labels in the order of the bin content, to index the content."""
         return [False, True]
-
-    def _pack(self):
-        return (self.__class__, getattr(self, "_original", self._expr))
 
 class _nullaxis(FixedAxis):
     def __repr__(self):
@@ -1243,6 +1244,9 @@ class profile(ProfileAxis):
     def __init__(self, expr):
         self._expr = expr
 
+    def _pack(self):
+        return (self.__class__, getattr(self, "_original", self._expr))
+
     def __repr__(self):
         return "profile({0})".format(repr(self._expr))
 
@@ -1265,6 +1269,3 @@ class profile(ProfileAxis):
 
     def __hash__(self):
         return hash((self.__class__, self._expr))
-
-    def _pack(self):
-        return (self.__class__, getattr(self, "_original", self._expr))

--- a/histbook/hist.py
+++ b/histbook/hist.py
@@ -776,3 +776,9 @@ class Hist(Fillable, histbook.proj.Projectable, histbook.export.Exportable, hist
                 add(self._content[n], other._content)
             else:
                 self._content[n] = Hist._copycontent(other._content)
+
+    # def __getstate__():
+    #     return None
+
+    # def __setstate__(state):
+    #     pass

--- a/histbook/hist.py
+++ b/histbook/hist.py
@@ -778,9 +778,10 @@ class Hist(Fillable, histbook.proj.Projectable, histbook.export.Exportable, hist
                 self._content[n] = Hist._copycontent(other._content)
 
     def __getstate__(self):
-        return (self._group + self._fixed + self._profile, self._weight, None if len(self._defs) == 0 else self._defs, self._content)
+        packed = tuple(x._pack() for x in self._group + self._fixed + self._profile)
+        return (packed, self._weight, None if len(self._defs) == 0 else self._defs, self._content)
 
     def __setstate__(self, state):
-        axis, weight, defs, content = state
-        self.__init__(*axis, weight=weight, defs=({} if defs is None else defs))
+        packed, weight, defs, content = state
+        self.__init__(*[histbook.axis.Axis._unpack(x) for x in packed], weight=weight, defs=({} if defs is None else defs))
         self._content = content

--- a/histbook/hist.py
+++ b/histbook/hist.py
@@ -777,8 +777,10 @@ class Hist(Fillable, histbook.proj.Projectable, histbook.export.Exportable, hist
             else:
                 self._content[n] = Hist._copycontent(other._content)
 
-    # def __getstate__():
-    #     return None
+    def __getstate__(self):
+        return (self._group + self._fixed + self._profile, self._weight, None if len(self._defs) == 0 else self._defs, self._content)
 
-    # def __setstate__(state):
-    #     pass
+    def __setstate__(self, state):
+        axis, weight, defs, content = state
+        self.__init__(*axis, weight=weight, defs=({} if defs is None else defs))
+        self._content = content

--- a/histbook/version.py
+++ b/histbook/version.py
@@ -30,7 +30,7 @@
 
 import re
 
-__version__ = "1.0.4"
+__version__ = "1.0.5"
 version = __version__
 version_info = tuple(re.split(r"[-\.]", __version__))
 


### PR DESCRIPTION
@imandr: inspired by our conversation about remotely filling `Hist` objects. A fairly minimal histogram of 10 bins

```python
h = Hist(bin("x", 10, -5, 5), fill=numpy.random.normal(0, 1, 1000000))
```

has 85% of its size in its metadata.

```python
>>> len(pickle.dumps(h._content, protocol=2))
255
>>> len(pickle.dumps(h, protocol=2))
1494
```

(Pickle protocol 2 is binary. Approximately the same _ratios_ for the default protocol 0 and the Python 3 protocols.)

In this PR comment stream, I'll post updates.